### PR TITLE
Add `Dockerfile`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/*
+!.cargo/
+!src/
+!Cargo.lock
+!Cargo.toml
+!sqlx-data.json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,8 @@ jobs:
             --locked
       - name: Start database
         run: ./scripts/init_db.sh >> $GITHUB_ENV
+      - name: Check schema sync
+        run: cargo sqlx prepare --check -- --lib
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,9 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1426,9 +1429,12 @@ dependencies = [
  "dotenv",
  "either",
  "heck",
+ "hex",
  "once_cell",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "sha2",
  "sqlx-core",
  "sqlx-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ envy = "0.4.2"
 futures = "0.3.21"
 hyper = "0.14.18"
 serde = { version = "1.0.136", features = ["derive"] }
-sqlx = { version = "0.5.11", features = ["macros", "migrate", "postgres", "runtime-tokio-rustls", "time", "uuid"], default-features = false }
+sqlx = { version = "0.5.11", features = ["macros", "migrate", "offline", "postgres", "runtime-tokio-rustls", "time", "uuid"], default-features = false }
 time = "0.2.27"
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tower = "0.4.12"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM rust:1.59.0-alpine AS chef
+WORKDIR app
+RUN apk add --no-cache libc-dev && cargo install cargo-chef
+
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+
+FROM chef AS builder
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+ENV SQLX_OFFLINE true
+RUN cargo build --release
+
+
+FROM scratch AS runtime
+
+WORKDIR /app
+COPY --from=builder /app/target/release/zero2prod zero2prod
+ENV ADDRESS 0.0.0.0
+ENTRYPOINT ["/app/zero2prod"]

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,0 +1,18 @@
+{
+  "db": "PostgreSQL",
+  "bcfcfebc6f5e8ffbf97d97c5a209be78b46d703924482cf8b43842705fcb7714": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Text",
+          "Timestamptz"
+        ]
+      }
+    },
+    "query": "\n        INSERT INTO subscriptions (id, email, name, subscribed_at)\n        VALUES ($1, $2, $3, $4)\n        "
+  }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,15 @@
+use std::net::IpAddr;
+
 use sqlx::postgres::PgConnectOptions;
 
 #[derive(serde::Deserialize)]
 pub struct Config {
+    #[serde(default, deserialize_with = "ip_addr_from_str")]
+    pub address: Option<IpAddr>,
+
     #[serde(default)]
     pub port: Option<u16>,
+
     #[serde(rename = "database_url", deserialize_with = "database_url_from_str")]
     pub database: PgConnectOptions,
 }
@@ -12,6 +18,16 @@ impl Config {
     pub fn from_env() -> Result<Self, envy::Error> {
         envy::from_env()
     }
+}
+
+fn ip_addr_from_str<'de, D>(deserializer: D) -> Result<Option<IpAddr>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let ip_addr: Option<String> = serde::Deserialize::deserialize(deserializer)?;
+    ip_addr
+        .map(|ip_addr| ip_addr.parse().map_err(serde::de::Error::custom))
+        .transpose()
 }
 
 fn database_url_from_str<'de, D>(deserializer: D) -> Result<PgConnectOptions, D::Error>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
-use std::net::Ipv4Addr;
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    time::Duration,
+};
 
-use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
 use tracing::info;
 
+const DEFAULT_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 const DEFAULT_PORT: u16 = 8000;
 
 #[tokio::main]
@@ -11,13 +15,17 @@ async fn main() -> zero2prod::ServerResult {
 
     let config = zero2prod::Config::from_env().expect("failed to read configuration");
 
-    let pool = PgPool::connect_with(config.database)
-        .await
-        .expect("failed to connect to database");
+    let pool = PgPoolOptions::new()
+        .connect_timeout(Duration::from_secs(2))
+        .connect_lazy_with(config.database);
 
     let server = zero2prod::bind(
         pool,
-        &(Ipv4Addr::LOCALHOST, config.port.unwrap_or(DEFAULT_PORT)).into(),
+        &(
+            config.address.unwrap_or(DEFAULT_ADDRESS),
+            config.port.unwrap_or(DEFAULT_PORT),
+        )
+            .into(),
     );
 
     info!("Listening on {}", server.local_addr());


### PR DESCRIPTION
- 2932991 **chore: add `Dockerfile` and config necessary to build/run it**

  The `Dockerfile` relies on `sqlx`'s offline mode in order to build
  without database access. This compels us to add a CI step to check that
  the `sqlx-data.json` is up-to-date. An `address` config has been added
  so that the docker container can bind to `0.0.0.0` rather than the
  default `127.0.0.1`. The `Dockerfile` uses `cargo-chef` to ensure
  dependency builds are cached.
  
  In a departure from the source material, we're using alpine from the
  get-go (10MB image), and using a whitelist-style `.dockerignore`.
