### PR TITLE
Deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 **/*
 !.cargo/
+!migrations/
 !src/
 !Cargo.lock
 !Cargo.toml

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,14 +1,20 @@
 name: Audit
-on:
-  push:
-    paths:
-      - '**/Cargo.lock'
-      - '**/Cargo.toml'
+
+on: pull_request
+
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Check if dependencies changed
+        id: changes
+        uses: tj-actions/verify-changed-files@v9
+        with:
+          files: |
+            **/Cargo.lock
+            **/Cargo.toml
       - uses: actions-rs/audit-check@v1
+        if: steps.changes.outputs.files_changed == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,8 +70,10 @@ jobs:
         uses: actions/cache@v2
         id: cache-sqlx
         with:
-          key: ${{ runner.os }}-sqlx-${{ env.SQLX_VERSION }}-${{ join(fromJSON(env.SQLX_FEATURES), '-') }}
-          path: ~/.cargo/bin/sqlx
+          key: ${{ runner.os }}-sqlx-${{ env.SQLX_VERSION }}-${{ join(fromJSON(env.SQLX_FEATURES), '-') }}-v1
+          path: |
+            ~/.cargo/bin/cargo-sqlx
+            ~/.cargo/bin/sqlx
       - name: Install sqlx-cli
         if: steps.cache-sqlx.outputs.cache-hit == false
         uses: actions-rs/cargo@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM rust:1.59.0-alpine AS chef
-WORKDIR app
-RUN apk add --no-cache libc-dev && cargo install cargo-chef
+WORKDIR /app
+RUN apk add --no-cache git libc-dev \
+  # Work around for a weird bug in DO app platform, which for some reason always fails when cargo
+  # tries to init this repo. It's not clear if the digest will ever change though.
+  && git config --global init.defaultBranch main && git init /usr/local/cargo/registry/index/github.com-1ecc6299db9ec823 \
+  && cargo install cargo-chef
 
 
 FROM chef AS planner

--- a/spec.yaml
+++ b/spec.yaml
@@ -1,0 +1,35 @@
+name: zero2prod
+
+region: lon
+
+services:
+  - name: zero2prod
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    dockerfile_path: Dockerfile
+    source_dir: .
+    http_port: 8000
+
+    envs:
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        type: SECRET
+        value: ${newsletter.DATABASE_URL}
+
+    github:
+      repo: connec/zero2prod
+      branch: deploy
+      deploy_on_push: true
+
+    health_check:
+      http_path: /health
+
+    routes:
+      - path: /
+
+databases:
+  - engine: PG
+    version: '12'
+    size: db-s-dev-database
+    num_nodes: 1
+    name: newsletter

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,22 +1,40 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use sqlx::postgres::PgConnectOptions;
+
+const DEFAULT_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+const DEFAULT_PORT: u16 = 8000;
 
 #[derive(serde::Deserialize)]
 pub struct Config {
     #[serde(default, deserialize_with = "ip_addr_from_str")]
-    pub address: Option<IpAddr>,
+    address: Option<IpAddr>,
 
     #[serde(default)]
-    pub port: Option<u16>,
+    port: Option<u16>,
 
     #[serde(rename = "database_url", deserialize_with = "database_url_from_str")]
-    pub database: PgConnectOptions,
+    database: PgConnectOptions,
 }
 
 impl Config {
     pub fn from_env() -> Result<Self, envy::Error> {
         envy::from_env()
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        SocketAddr::from((
+            self.address.unwrap_or(DEFAULT_ADDRESS),
+            self.port.unwrap_or(DEFAULT_PORT),
+        ))
+    }
+
+    pub fn database_options(&self) -> PgConnectOptions {
+        self.database.clone()
+    }
+
+    pub fn database_options_with_database(&self, name: &str) -> PgConnectOptions {
+        self.database.clone().database(name)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,7 @@
-use std::{
-    net::{IpAddr, Ipv4Addr},
-    time::Duration,
-};
+use std::time::Duration;
 
 use sqlx::postgres::PgPoolOptions;
 use tracing::info;
-
-const DEFAULT_ADDRESS: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-const DEFAULT_PORT: u16 = 8000;
 
 #[tokio::main]
 async fn main() -> zero2prod::ServerResult {
@@ -17,16 +11,9 @@ async fn main() -> zero2prod::ServerResult {
 
     let pool = PgPoolOptions::new()
         .connect_timeout(Duration::from_secs(2))
-        .connect_lazy_with(config.database);
+        .connect_lazy_with(config.database_options());
 
-    let server = zero2prod::bind(
-        pool,
-        &(
-            config.address.unwrap_or(DEFAULT_ADDRESS),
-            config.port.unwrap_or(DEFAULT_PORT),
-        )
-            .into(),
-    );
+    let server = zero2prod::bind(pool, &config.addr());
 
     info!("Listening on {}", server.local_addr());
 


### PR DESCRIPTION
- 327968e **ci: add spec.yaml for deployment to DigitalOcean App Platform**

  Sadly this needs to be manually sync'd with DO for now, using
  `doctl apps update <id> --spec spec.yaml`. It would be nice if DO could
  sync itself from a file in the repo before deploying...
  
  The spec is pretty simple, and consists of a service that will build and
  serve the Dockerfile, and a database.

- ffd02ff **refactor: add convenient getters to `Config`**

  The fields of `Config` are now all private, and instead some convenient
  getters can be used to obtain the configuration.

- 418768f **chore: run migrations on startup**

  This saves us from having to manually run them against the deployed
  database.

- 8b94dac **ci: fix caching of `sqlx` binaries in `clippy` job**

  The "Check schema sync" step requires the `cargo-sqlx` binary to be
  present, which wasn't being included in the cache. This also requires
  invalidating the existing cache, which was achieved by adding a `-v1`
  suffix (pre-empting possible future invalidation needs...).

- 1adf911 **ci: always run audit job, but only run audit step if deps changed**

  This ensures we have an "Audit" check we can require on pull requests.
