### PR TITLE
Validate subscribe inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,18 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -44,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "axum"
@@ -167,6 +176,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "claim"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81099d6bb72e1df6d50bb2347224b666a670912bb7f06dbe867a4a070ab3ce8"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "const_fn"
@@ -304,12 +322,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "fake"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6479fa2c7e83ddf8be7d435421e093b072ca891b99a49bc84eba098f4044f818"
+dependencies = [
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -470,6 +507,17 @@ checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -705,11 +753,10 @@ checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1016,6 +1063,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,13 +1096,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1042,7 +1135,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1051,7 +1153,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1069,10 +1180,27 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
  "redox_syscall",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1400,7 +1528,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rustls",
  "serde",
  "serde_json",
@@ -1919,7 +2047,33 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.6",
+]
+
+[[package]]
+name = "validator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0f08911ab0fee2c5009580f04615fa868898ee57de10692a45da0c3bcc3e5e"
+dependencies = [
+ "idna",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded9d97e1d42327632f5f3bae6403c04886e2de3036261ef42deebd931a6a291"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1949,6 +2103,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2147,9 +2307,13 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "axum-sqlx-tx",
+ "claim",
  "envy",
+ "fake",
  "futures",
  "hyper",
+ "quickcheck",
+ "quickcheck_macros",
  "reqwest",
  "serde",
  "sqlx",
@@ -2160,5 +2324,7 @@ dependencies = [
  "tracing",
  "tracing-bunyan-formatter",
  "tracing-subscriber",
+ "unicode-segmentation",
  "uuid",
+ "validator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,15 @@ tower-http = { version = "0.2.5", features = ["trace"] }
 tracing = "0.1.32"
 tracing-bunyan-formatter = "0.3.2"
 tracing-subscriber = "0.3.10"
+unicode-segmentation = "1.9.0"
 uuid = { version = "0.8.2", features = ["v4"] }
+validator = "0.14.0"
 
 [features]
 
 [dev-dependencies]
+claim = "0.5.0"
+fake = "~2.3"
+quickcheck = "0.9"
+quickcheck_macros = "0.9"
 reqwest = "0.11.10"

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,17 @@
+mod new_subscriber;
+mod subscriber_email;
+mod subscriber_name;
+
+pub(crate) use self::{
+    new_subscriber::NewSubscriber, subscriber_email::SubscriberEmail,
+    subscriber_name::SubscriberName,
+};
+
+#[derive(Debug)]
+pub(crate) struct Error(String);
+
+impl From<Error> for crate::Error {
+    fn from(error: Error) -> Self {
+        Self::Validation(error.0)
+    }
+}

--- a/src/domain/new_subscriber.rs
+++ b/src/domain/new_subscriber.rs
@@ -1,0 +1,6 @@
+use super::{subscriber_email::SubscriberEmail, subscriber_name::SubscriberName};
+
+pub(crate) struct NewSubscriber {
+    pub email: SubscriberEmail,
+    pub name: SubscriberName,
+}

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -1,0 +1,61 @@
+use super::Error;
+
+#[derive(Debug)]
+pub(crate) struct SubscriberEmail(String);
+
+impl SubscriberEmail {
+    pub(crate) fn parse(s: String) -> Result<Self, Error> {
+        if validator::validate_email(&s) {
+            Ok(Self(s))
+        } else {
+            Err(Error(format!("{} is not a valid email", s)))
+        }
+    }
+}
+
+impl AsRef<str> for SubscriberEmail {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use claim::assert_err;
+    use fake::{faker::internet::en::FreeEmail, Fake};
+
+    use super::SubscriberEmail;
+
+    #[derive(Clone, Debug)]
+    struct ValidEmailFixture(pub String);
+
+    impl quickcheck::Arbitrary for ValidEmailFixture {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            let email = FreeEmail().fake_with_rng(g);
+            Self(email)
+        }
+    }
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let email = "".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_at_symbol_is_rejected() {
+        let email = "ursuladomain.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_subject_is_rejected() {
+        let email = "@domain.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn valid_emails_are_parsed_successfully(email: ValidEmailFixture) -> bool {
+        SubscriberEmail::parse(email.0).is_ok()
+    }
+}

--- a/src/domain/subscriber_name.rs
+++ b/src/domain/subscriber_name.rs
@@ -1,0 +1,72 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+use super::Error;
+
+const INVALID_CHARS: [char; 9] = ['/', '(', ')', '"', '<', '>', '\\', '{', '}'];
+
+#[derive(Debug)]
+pub(crate) struct SubscriberName(String);
+
+impl SubscriberName {
+    pub(crate) fn parse(s: String) -> Result<Self, Error> {
+        if s.trim().is_empty()
+            || s.graphemes(true).count() > 256
+            || s.chars().any(|c| INVALID_CHARS.contains(&c))
+        {
+            Err(Error(format!("{} is not a valid subscriber name", s)))
+        } else {
+            Ok(Self(s))
+        }
+    }
+}
+
+impl AsRef<str> for SubscriberName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use claim::{assert_err, assert_ok};
+
+    use super::SubscriberName;
+
+    #[test]
+    fn a_256_grapheme_long_name_is_valid() {
+        let name = "ë".repeat(256);
+        assert_ok!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn a_name_longer_than_256_graphemes_is_rejected() {
+        let name = "ë".repeat(257);
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn whitespace_only_names_are_rejected() {
+        let name = " ".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let name = "".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn names_containing_an_invalid_character_are_rejected() {
+        for name in ['/', '(', ')', '"', '<', '>', '\\', '{', '}'] {
+            let name = name.to_string();
+            assert_err!(SubscriberName::parse(name));
+        }
+    }
+
+    #[test]
+    fn a_valid_name_is_parsed_successfully() {
+        let name = "Ursula Le Guin".to_string();
+        assert_ok!(SubscriberName::parse(name));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod config;
+mod domain;
 mod routes;
 mod server;
 pub mod telemetry;
@@ -18,30 +19,45 @@ pub use self::{
 pub(crate) type Tx = axum_sqlx_tx::Tx<sqlx::Postgres, Error>;
 
 #[derive(Clone, Debug)]
-pub(crate) struct Error(String);
+pub(crate) enum Error {
+    Validation(String),
+    Internal(String),
+}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(
+            f,
+            "{}",
+            match self {
+                Error::Validation(error) => error,
+                Error::Internal(error) => error,
+            }
+        )
     }
 }
 
 impl From<sqlx::Error> for Error {
     fn from(error: sqlx::Error) -> Self {
-        Self(error.to_string())
+        Self::Internal(error.to_string())
     }
 }
 
 impl From<axum_sqlx_tx::Error> for Error {
     fn from(error: axum_sqlx_tx::Error) -> Self {
-        Self(error.to_string())
+        Self::Internal(error.to_string())
     }
 }
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        let mut response = StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        response.extensions_mut().insert(self);
-        response
+        match self {
+            Self::Validation(error) => (StatusCode::UNPROCESSABLE_ENTITY, error).into_response(),
+            error @ Self::Internal(_) => {
+                let mut response = StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                response.extensions_mut().insert(error);
+                response
+            }
+        }
     }
 }

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,8 +1,11 @@
-use axum::extract::Form;
+use axum::{extract::Form, http::StatusCode};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::{Error, Tx};
+use crate::{
+    domain::{self, NewSubscriber, SubscriberEmail, SubscriberName},
+    Error, Tx,
+};
 
 #[derive(serde::Deserialize)]
 pub(crate) struct Subscriber {
@@ -10,19 +13,42 @@ pub(crate) struct Subscriber {
     email: String,
 }
 
+impl TryFrom<Subscriber> for NewSubscriber {
+    type Error = domain::Error;
+
+    fn try_from(value: Subscriber) -> Result<Self, Self::Error> {
+        Ok(NewSubscriber {
+            email: SubscriberEmail::parse(value.email)?,
+            name: SubscriberName::parse(value.name)?,
+        })
+    }
+}
+
 #[tracing::instrument(skip(tx, form))]
-pub(crate) async fn subscribe(mut tx: Tx, Form(form): Form<Subscriber>) -> Result<(), Error> {
+pub(crate) async fn subscribe(
+    mut tx: Tx,
+    Form(form): Form<Subscriber>,
+) -> Result<StatusCode, Error> {
+    let input = form.try_into()?;
+
+    insert_subscriber(&mut tx, input).await?;
+
+    Ok(StatusCode::OK)
+}
+
+async fn insert_subscriber(tx: &mut Tx, input: NewSubscriber) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
         INSERT INTO subscriptions (id, email, name, subscribed_at)
         VALUES ($1, $2, $3, $4)
         "#,
         Uuid::new_v4(),
-        form.email,
-        form.name,
+        input.email.as_ref(),
+        input.name.as_ref(),
         OffsetDateTime::now_utc(),
     )
-    .execute(&mut tx)
+    .execute(tx)
     .await?;
+
     Ok(())
 }

--- a/src/telemetry/requests.rs
+++ b/src/telemetry/requests.rs
@@ -142,7 +142,7 @@ impl ClassifyResponse for Classifier {
 
         match self.fallback.classify_response(response) {
             ClassifiedResponse::Ready(res) => {
-                ClassifiedResponse::Ready(res.map_err(|error| Error(error.to_string())))
+                ClassifiedResponse::Ready(res.map_err(|error| Error::Internal(error.to_string())))
             }
             // `NeverClassifyEos` values cannot exist (it uses `Infallible` internally)
             ClassifiedResponse::RequiresEos(_) => unreachable!(),
@@ -153,6 +153,6 @@ impl ClassifyResponse for Classifier {
     where
         E: std::fmt::Display + 'static,
     {
-        Error(error.to_string())
+        Error::Internal(error.to_string())
     }
 }


### PR DESCRIPTION
- 641564d **feat: validate subscribe inputs**

  This introduces a `domain` mod wherein lives a `NewSubscriber` type
  whose fields, `SubscriberEmail` and `SubcriberName`, are newtypes that
  assert the validity of the underlying `String`s on construction. Parse
  errors are expressed using `domain::Error`. `quickcheck` is used to test
  email inputs, generated with `fake` – though `fake` doesn't seem
  particularly good for exercising parsing as all the emails look very
  pedestrian.
  
  The `crate::Error` type has been converted to an enum with variants for
  `Internal` errors and `Validation` errors. All extant error handling was
  converted to use the `Internal` variant, whereas `domain::Error`
  converts to `crate::Error::Validation`. The `IntoResponse`
  implementation converts to a `422 Unprocessable Entity` response
  containing the error message (in plain text, for now). Only `Internal`
  errors get additional logging.
