### PR TITLE
Update address to full `SocketAddr`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,4 @@ FROM scratch AS runtime
 
 WORKDIR /app
 COPY --from=builder /app/target/release/zero2prod zero2prod
-ENV ADDRESS 0.0.0.0
 ENTRYPOINT ["/app/zero2prod"]

--- a/spec.yaml
+++ b/spec.yaml
@@ -11,6 +11,10 @@ services:
     http_port: 8000
 
     envs:
+      - key: ADDRESS
+        scope: RUN_TIME
+        type: GENERAL
+        value: 0.0.0.0:8000
       - key: DATABASE_URL
         scope: RUN_TIME
         type: SECRET


### PR DESCRIPTION
- b4e105c **fix: update address to full `SocketAddr`**

  This was missed when the config was moved around. To limit the spread of
  configuration, the value for `ADDRESS` has been moved into `spec.yaml`.
  This is arguably worse for the default Docker case, but a more paranoid
  person might say it's not a good idea to assume that even containers
  should bind to `0.0.0.0` by default.
