### PR TITLE
Confirmation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
+name = "linkify"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccbcd666d915aa3ae3c3774999a9e20b2776a018309b8159d07df062b91f45e8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.6",
+ "serde",
 ]
 
 [[package]]
@@ -2391,6 +2401,7 @@ dependencies = [
  "fake",
  "futures",
  "hyper",
+ "linkify",
  "quickcheck",
  "quickcheck_macros",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fake"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +776,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -2371,6 +2387,7 @@ dependencies = [
  "axum-sqlx-tx",
  "claim",
  "envy",
+ "eyre",
  "fake",
  "futures",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 axum = "0.5.0"
 axum-sqlx-tx = { version = "0.3.0", features = ["postgres"] }
 envy = "0.4.2"
+eyre = "0.6.8"
 futures = "0.3.21"
 hyper = "0.14.18"
 reqwest = { version = "0.11.10", default-features = false, features = ["json", "rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tracing = "0.1.32"
 tracing-bunyan-formatter = "0.3.2"
 tracing-subscriber = "0.3.10"
 unicode-segmentation = "1.9.0"
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "0.8.2", features = ["serde", "v4"] }
 validator = "0.14.0"
 
 [features]
@@ -31,6 +31,7 @@ validator = "0.14.0"
 [dev-dependencies]
 claim = "0.5.0"
 fake = "~2.3"
+linkify = "0.8.0"
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
 serde_json = "1.0.79"

--- a/migrations/20220410212230_create_subscription_tokens.sql
+++ b/migrations/20220410212230_create_subscription_tokens.sql
@@ -1,0 +1,4 @@
+CREATE TABLE subscription_tokens (
+  id uuid NOT NULL PRIMARY KEY,
+  subscriber_id uuid NOT NULL REFERENCES subscriptions (id)
+);

--- a/spec.yaml
+++ b/spec.yaml
@@ -15,6 +15,10 @@ services:
         scope: RUN_TIME
         type: GENERAL
         value: 0.0.0.0:8000
+      - key: BASE_URL
+        scope: RUN_TIME
+        type: GENERAL
+        value: ${APP_URL}
       - key: DATABASE_URL
         scope: RUN_TIME
         type: SECRET

--- a/spec.yaml
+++ b/spec.yaml
@@ -21,12 +21,28 @@ services:
         value: ${APP_URL}
       - key: DATABASE_URL
         scope: RUN_TIME
-        type: SECRET
+        type: GENERAL
         value: ${newsletter.DATABASE_URL}
       - key: IGNORE_MISSING_MIGRATIONS
         scope: RUN_TIME
         type: GENERAL
         value: 'true'
+      - key: EMAIL_BASE_URL
+        scope: RUN_TIME
+        type: GENERAL
+        value: https://api.postmarkapp.com/
+      - key: EMAIL_SENDER
+        scope: RUN_TIME
+        type: GENERAL
+        value: chris@connec.co.uk
+      - key: EMAIL_AUTHORIZATION_TOKEN
+        scope: RUN_TIME
+        type: GENERAL
+        value: ${EMAIL_AUTHORIZATION_TOKEN}
+      - key: EMAIL_SEND_TIMEOUT_MS
+        scope: RUN_TIME
+        type: GENERAL
+        value: '2000'
 
     github:
       repo: connec/zero2prod

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,9 +1,71 @@
 {
   "db": "PostgreSQL",
-  "bcfcfebc6f5e8ffbf97d97c5a209be78b46d703924482cf8b43842705fcb7714": {
+  "2f536b16a1a631ea442f4ff838070f9b192f1f0f566733873f74de3925a75490": {
     "describe": {
       "columns": [],
       "nullable": [],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n        UPDATE subscriptions\n        SET status = $1\n        WHERE subscriptions.id = $2\n        "
+  },
+  "355cacfbe5c01d62ab98f7c20cb888170e1960477482a167246625c3c1a63b61": {
+    "describe": {
+      "columns": [
+        {
+          "name": "subscriber_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "SELECT subscriber_id FROM subscription_tokens WHERE id = $1"
+  },
+  "3a7882dc2b0d64b599e75ece3a16470d7a865e35cf9392433c4a3ca05da5b0e7": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n        INSERT INTO subscription_tokens (id, subscriber_id)\n        VALUES ($1, $2)\n        RETURNING id\n        "
+  },
+  "4e814f697c91bfcb9c9614aa6285f872bb292f0f12fee6273b1c1916cc2f188c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
       "parameters": {
         "Left": [
           "Uuid",
@@ -13,6 +75,6 @@
         ]
       }
     },
-    "query": "\n        INSERT INTO subscriptions (id, email, name, subscribed_at)\n        VALUES ($1, $2, $3, $4)\n        "
+    "query": "\n        INSERT INTO subscriptions (id, email, name, subscribed_at)\n        VALUES ($1, $2, $3, $4)\n        RETURNING id\n        "
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use crate::domain::SubscriberEmail;
 
 pub struct Config {
     pub(crate) address: SocketAddr,
+    pub(crate) base_url: Url,
     pub(crate) database_options: PgConnectOptions,
     pub(crate) ignore_missing_migrations: bool,
     pub(crate) email_base_url: Url,
@@ -35,6 +36,9 @@ pub struct ConfigBuilder {
     #[serde(default, deserialize_with = "parse_optional")]
     address: Option<SocketAddr>,
 
+    #[serde(default, deserialize_with = "parse_optional")]
+    base_url: Option<Url>,
+
     #[serde(default, rename = "database_url", deserialize_with = "parse_optional")]
     database_options: Option<PgConnectOptions>,
 
@@ -62,6 +66,7 @@ impl ConfigBuilder {
     fn empty() -> Self {
         Self {
             address: None,
+            base_url: None,
             database_options: None,
             ignore_missing_migrations: None,
             email_base_url: None,
@@ -73,18 +78,18 @@ impl ConfigBuilder {
 
     fn default() -> Self {
         Self {
-            address: None,
-            database_options: None,
             ignore_missing_migrations: Some(false),
-            email_base_url: None,
-            email_sender: None,
-            email_authorization_token: None,
-            email_send_timeout: None,
+            ..Self::empty()
         }
     }
 
     pub fn address(mut self, address: SocketAddr) -> Self {
         self.address = Some(address);
+        self
+    }
+
+    pub fn base_url(mut self, base_url: Url) -> Self {
+        self.base_url = Some(base_url);
         self
     }
 
@@ -131,6 +136,11 @@ impl ConfigBuilder {
                 .or(self.address)
                 .or(default.address)
                 .ok_or(envy::Error::MissingValue("address"))?,
+            base_url: overrides
+                .base_url
+                .or(self.base_url)
+                .or(default.base_url)
+                .ok_or(envy::Error::MissingValue("base_url"))?,
             database_options: overrides
                 .database_options
                 .or(self.database_options)

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -19,6 +19,6 @@ impl fmt::Display for Error {
 
 impl From<Error> for crate::Error {
     fn from(error: Error) -> Self {
-        Self::Validation(error.0)
+        Self::Validation(error.to_string())
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,10 +1,14 @@
 mod new_subscriber;
 mod subscriber_email;
 mod subscriber_name;
+mod subscriber_status;
 
 use std::fmt;
 
-pub(crate) use self::{new_subscriber::NewSubscriber, subscriber_name::SubscriberName};
+pub(crate) use self::{
+    new_subscriber::NewSubscriber, subscriber_name::SubscriberName,
+    subscriber_status::SubscriberStatus,
+};
 
 pub use self::subscriber_email::SubscriberEmail;
 

--- a/src/domain/subscriber_status.rs
+++ b/src/domain/subscriber_status.rs
@@ -1,0 +1,29 @@
+#[derive(Clone, Copy)]
+pub(crate) enum SubscriberStatus {
+    Pending,
+    Confirmed,
+}
+
+impl SubscriberStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Confirmed => "confirmed",
+        }
+    }
+}
+
+impl std::str::FromStr for SubscriberStatus {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, crate::Error> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "confirmed" => Ok(Self::Confirmed),
+            _ => Err(crate::Error::Internal(eyre::Report::msg(format!(
+                "unknown subscriber status: {}",
+                s
+            )))),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 
 pub use self::{
-    app::{App, Server},
+    app::{App, AppBaseUrl, Server},
     config::Config,
     email_client::EmailClient,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod email_client;
 mod routes;
 pub mod telemetry;
 
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use axum::{
     http::StatusCode,
@@ -20,34 +20,30 @@ pub use self::{
 
 pub(crate) type Tx = axum_sqlx_tx::Tx<sqlx::Postgres, Error>;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) enum Error {
     Validation(String),
-    Internal(String),
+    Internal(eyre::Report),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Error::Validation(error) => error,
-                Error::Internal(error) => error,
-            }
-        )
+        match self {
+            Error::Validation(error) => write!(f, "{}", error),
+            Error::Internal(error) => write!(f, "{}", error),
+        }
     }
 }
 
 impl From<sqlx::Error> for Error {
     fn from(error: sqlx::Error) -> Self {
-        Self::Internal(error.to_string())
+        Self::Internal(error.into())
     }
 }
 
 impl From<axum_sqlx_tx::Error> for Error {
     fn from(error: axum_sqlx_tx::Error) -> Self {
-        Self::Internal(error.to_string())
+        Self::Internal(error.into())
     }
 }
 
@@ -55,9 +51,9 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         match self {
             Self::Validation(error) => (StatusCode::UNPROCESSABLE_ENTITY, error).into_response(),
-            error @ Self::Internal(_) => {
+            Self::Internal(error) => {
                 let mut response = StatusCode::INTERNAL_SERVER_ERROR.into_response();
-                response.extensions_mut().insert(error);
+                response.extensions_mut().insert(Arc::new(error));
                 response
             }
         }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,7 @@
 mod health;
 mod subscriptions;
+mod subscriptions_confirm;
 
 pub(crate) use health::*;
 pub(crate) use subscriptions::*;
+pub(crate) use subscriptions_confirm::*;

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,10 +1,11 @@
-use axum::{extract::Form, http::StatusCode};
+use axum::{extract::Form, http::StatusCode, Extension};
+use reqwest::Url;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::{
     domain::{self, NewSubscriber, SubscriberEmail, SubscriberName},
-    Error, Tx,
+    email_client, AppBaseUrl, EmailClient, Error, Tx,
 };
 
 #[derive(serde::Deserialize)]
@@ -24,31 +25,80 @@ impl TryFrom<Subscriber> for NewSubscriber {
     }
 }
 
-#[tracing::instrument(skip(tx, form))]
+#[tracing::instrument(skip_all)]
 pub(crate) async fn subscribe(
     mut tx: Tx,
+    base_url: Extension<AppBaseUrl>,
+    email_client: Extension<EmailClient>,
     Form(form): Form<Subscriber>,
 ) -> Result<StatusCode, Error> {
-    let input = form.try_into()?;
+    let subscriber = form.try_into()?;
 
-    insert_subscriber(&mut tx, input).await?;
+    let subscriber_id = insert_subscriber(&mut tx, &subscriber).await?;
+    let token = insert_subscription_token(&mut tx, &subscriber_id).await?;
+    send_confirmation_email(&base_url, &email_client, subscriber, &token).await?;
 
     Ok(StatusCode::OK)
 }
 
-async fn insert_subscriber(tx: &mut Tx, input: NewSubscriber) -> Result<(), sqlx::Error> {
+async fn insert_subscriber(tx: &mut Tx, input: &NewSubscriber) -> Result<Uuid, sqlx::Error> {
     sqlx::query!(
         r#"
         INSERT INTO subscriptions (id, email, name, subscribed_at)
         VALUES ($1, $2, $3, $4)
+        RETURNING id
         "#,
         Uuid::new_v4(),
         input.email.as_ref(),
         input.name.as_ref(),
         OffsetDateTime::now_utc(),
     )
-    .execute(tx)
-    .await?;
+    .fetch_one(tx)
+    .await
+    .map(|row| row.id)
+}
 
-    Ok(())
+#[tracing::instrument(skip_all)]
+async fn insert_subscription_token(tx: &mut Tx, subscriber_id: &Uuid) -> Result<Uuid, sqlx::Error> {
+    sqlx::query!(
+        r#"
+        INSERT INTO subscription_tokens (id, subscriber_id)
+        VALUES ($1, $2)
+        RETURNING id
+        "#,
+        Uuid::new_v4(),
+        subscriber_id,
+    )
+    .fetch_one(tx)
+    .await
+    .map(|row| row.id)
+}
+
+#[tracing::instrument(skip_all)]
+async fn send_confirmation_email(
+    base_url: &Url,
+    email_client: &EmailClient,
+    subscriber: NewSubscriber,
+    token: &Uuid,
+) -> Result<(), email_client::Error> {
+    let mut confirmation_link = base_url.join("/subscriptions/confirm").unwrap();
+    confirmation_link
+        .query_pairs_mut()
+        .append_pair("token", &token.to_string());
+
+    let html_body = format!(
+        "Welcome to our newsletter!<br />\
+        Click <a href=\"{}\">here</a> to confirm your subscription.",
+        confirmation_link,
+    );
+
+    let text_body = format!(
+        "Welcome to our newsletter!\n\
+        Visit {} to confirm your subscription.",
+        confirmation_link,
+    );
+
+    email_client
+        .send_email(subscriber.email, "Welcome!", &html_body, &text_body)
+        .await
 }

--- a/src/routes/subscriptions_confirm.rs
+++ b/src/routes/subscriptions_confirm.rs
@@ -1,0 +1,53 @@
+use axum::{extract::Query, http::StatusCode};
+use uuid::Uuid;
+
+use crate::{domain::SubscriberStatus, Error, Tx};
+
+#[tracing::instrument(skip_all)]
+pub(crate) async fn confirm(mut tx: Tx, params: Query<Params>) -> Result<StatusCode, Error> {
+    let subscriber_id = match get_subscriber_id(&mut tx, &params.token).await? {
+        None => return Ok(StatusCode::UNAUTHORIZED),
+        Some(id) => id,
+    };
+
+    confirm_subscription(&mut tx, &subscriber_id).await?;
+
+    Ok(StatusCode::OK)
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct Params {
+    token: Uuid,
+}
+
+#[tracing::instrument(skip_all)]
+async fn get_subscriber_id(
+    tx: &mut Tx,
+    subscription_token_id: &Uuid,
+) -> Result<Option<Uuid>, sqlx::Error> {
+    let row = sqlx::query!(
+        r#"SELECT subscriber_id FROM subscription_tokens WHERE id = $1"#,
+        subscription_token_id,
+    )
+    .fetch_optional(tx)
+    .await?;
+
+    Ok(row.map(|row| row.subscriber_id))
+}
+
+#[tracing::instrument(skip_all)]
+async fn confirm_subscription(tx: &mut Tx, subscriber_id: &Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        UPDATE subscriptions
+        SET status = $1
+        WHERE subscriptions.id = $2
+        "#,
+        SubscriberStatus::Confirmed.as_str(),
+        subscriber_id,
+    )
+    .execute(tx)
+    .await?;
+
+    Ok(())
+}

--- a/tests/api/subscriptions.rs
+++ b/tests/api/subscriptions.rs
@@ -1,15 +1,40 @@
+mod confirm;
+
 use axum::http::StatusCode;
+use wiremock::{
+    matchers::{method, path},
+    Mock, ResponseTemplate,
+};
 
 use crate::helpers::TestApp;
 
 #[tokio::test]
 async fn subscribe_returns_a_200_for_valid_form_data() {
     let app = TestApp::spawn().await;
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
 
     let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
     let response = app.post_subscriptions(body).await;
 
     assert_status("valid", StatusCode::OK, response).await;
+}
+
+#[tokio::test]
+async fn subscribe_persists_a_new_subscriber() {
+    let app = TestApp::spawn().await;
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+    app.post_subscriptions(body).await;
+
     let saved = sqlx::query!("SELECT email, name, status FROM subscriptions")
         .fetch_one(&app.pool)
         .await
@@ -48,6 +73,79 @@ async fn subscribe_returns_a_422_when_fields_are_present_but_invalid() {
 
         assert_status(problem, StatusCode::UNPROCESSABLE_ENTITY, response).await;
     }
+}
+
+#[tokio::test]
+async fn subscribe_sends_a_confirmation_email_with_a_link() {
+    let app = TestApp::spawn().await;
+    let body = "name=le%20guin&email=ursula_le_guin@gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&app.email_server)
+        .await;
+
+    app.post_subscriptions(body).await;
+
+    let email_request = &app.email_server.received_requests().await.unwrap()[0];
+    let links = app.get_confirmation_links(email_request);
+
+    assert_eq!(links.html, links.text);
+}
+
+#[tokio::test]
+async fn the_link_returned_by_subscribe_returns_a_200_if_called() {
+    let app = TestApp::spawn().await;
+    let body = "name=le%20guin&email=ursula_le_guin@gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
+
+    app.post_subscriptions(body).await;
+
+    let email_request = &app.email_server.received_requests().await.unwrap()[0];
+    let links = app.get_confirmation_links(email_request);
+
+    let response = reqwest::get(links.html).await.unwrap();
+
+    assert_eq!(response.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn the_link_returned_by_subscribe_confirms_a_subscriber() {
+    let app = TestApp::spawn().await;
+    let body = "name=le%20guin&email=ursula_le_guin@gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&app.email_server)
+        .await;
+
+    app.post_subscriptions(body).await;
+
+    let email_request = &app.email_server.received_requests().await.unwrap()[0];
+    let links = app.get_confirmation_links(email_request);
+
+    reqwest::get(links.html)
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    let saved = sqlx::query!("SELECT email, name, status FROM subscriptions")
+        .fetch_one(&app.pool)
+        .await
+        .expect("failed to fetch saved subscription");
+
+    assert_eq!(saved.email, "ursula_le_guin@gmail.com");
+    assert_eq!(saved.name, "le guin");
+    assert_eq!(saved.status, "confirmed");
 }
 
 async fn assert_status(problem: &str, expected: StatusCode, response: reqwest::Response) {

--- a/tests/api/subscriptions/confirm.rs
+++ b/tests/api/subscriptions/confirm.rs
@@ -1,0 +1,12 @@
+use crate::helpers::TestApp;
+
+#[tokio::test]
+async fn confirmations_without_token_are_rejected_with_a_422() {
+    let app = TestApp::spawn().await;
+
+    let response = reqwest::get(app.base_url.join("/subscriptions/confirm").unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status().as_u16(), 422);
+}


### PR DESCRIPTION
- 89b522c **refactor: use `eyre` to record internal errors**

  This increases the amount of information included in the logs when an
  error occurs. It's not particularly well formatted for JSON, but at
  least the error chain is there.

- e24f83c **feat: implement confirmation emails**

  Confirmation emails are sent to new subscribers, including a link to
  confirm the subscription. The confirmation links go to a new endpoint,
  `/subscriptions/confirm?token=<token>`. The `token` needs to match one
  inserted into `/subscriptions`, which happens on every successful
  subscription.

- e75fc15 **ci: add missing config to `spec.yaml`**

  The `EMAIL_AUTHORIZATION_TOKEN` has been stored in an app-level
  environment variable, to avoid committing anything sensitive into the
  repo (encrypted or otherwise). Additionally the `DATABASE_URL` has been
  converted to a `GENERAL` secret since it's also just a reference.
