### PR TITLE
Add a merge workflow to update the app spec

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -1,0 +1,21 @@
+name: Merge
+
+on:
+  push:
+    branches: fix-config
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v3
+      - uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Update app
+        run: scripts/update-app.sh
+        env:
+          APP_ID: ${{ secrets.DIGITALOCEAN_APP_ID }}
+          EMAIL_SENDER: ${{ secrets.EMAIL_SENDER }}
+          EMAIL_AUTHORIZATION_TOKEN: ${{ secrets.EMAIL_AUTHORIZATION_TOKEN }}

--- a/scripts/update-app.sh
+++ b/scripts/update-app.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_vars=(
+  APP_ID
+  $(grep -oE '\{\{[_A-Z][_A-Z0-9]*\}\}' spec.yaml | tr -d '{}')
+)
+missing_vars=()
+shell_format=''
+
+for var in "${required_vars[@]}" ; do
+  shell_format="$shell_format \$$var"
+  if [[ -z "${!var-}" ]]; then
+    missing_vars+=("$var")
+  fi
+done
+
+if [[ "${#missing_vars[@]}" -gt 0 ]]; then
+  echo >&2 "Missing required vars:"
+
+  if [[ -t 1 ]]; then
+    for var in "${missing_vars[@]}"; do
+      read -esp "$var: 🔒" "$var"
+      echo
+    done
+  else
+    for var in "${missing_vars[@]}"; do
+      echo >&2 "- $var"
+    done
+    exit 1
+  fi
+fi
+
+spec="$(cat spec.yaml)"
+for var in "${required_vars[@]}" ; do
+  value="$(echo "${!var}" | jq -R)"
+  spec="$(echo "$spec" | sed "s/{{$var}}/$value/")"
+done
+
+echo "$spec" | doctl apps update "$APP_ID" -o json --spec - --wait

--- a/spec.yaml
+++ b/spec.yaml
@@ -34,11 +34,11 @@ services:
       - key: EMAIL_SENDER
         scope: RUN_TIME
         type: GENERAL
-        value: chris@connec.co.uk
+        value: {{EMAIL_SENDER}}
       - key: EMAIL_AUTHORIZATION_TOKEN
         scope: RUN_TIME
-        type: GENERAL
-        value: ${EMAIL_AUTHORIZATION_TOKEN}
+        type: SECRET
+        value: {{EMAIL_AUTHORIZATION_TOKEN}}
       - key: EMAIL_SEND_TIMEOUT_MS
         scope: RUN_TIME
         type: GENERAL


### PR DESCRIPTION
- 0f9765a **ci: add a merge workflow to update the app spec**

  This brings the DigitalOcean App spec into continuous deployment. The
  `spec.yaml` now includes placeholders that must be substituted
  externally (it is invalid YAML, otherwise). `scripts/update-app.sh` can
  be used to substitute the placeholders from environment variables
  (either pre-set, or prompted if run from a TTY) and update the
  DigitalOcean App. The `--wait` flag is used to wait for the deployment
  to conclude (and hopefully report an error if it fails, but this hasn't
  been tested!).
